### PR TITLE
[FEAT] : 권한별 사이드 바 오류 수정 및 탭 지정 

### DIFF
--- a/src/components/layout/content/contractManager/statisticsResults/BottomTable.css
+++ b/src/components/layout/content/contractManager/statisticsResults/BottomTable.css
@@ -1,0 +1,59 @@
+.customTable {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-top: 20px;
+  border-radius: 1rem;
+  overflow: hidden;
+  background-color: #ffffff;
+  border: none;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  font-size: 90%;
+}
+
+.customTable th,
+.customTable td {
+  padding: 15px 20px;
+  text-align: center;
+}
+
+.customTable th {
+  background-color: white;
+  color: #121824;
+  font-weight: 300;
+  border-bottom: 2px solid #e0e0e0;
+  text-transform: uppercase;
+}
+
+.customTable tbody tr:nth-child(odd) {
+  background-color: #eef8fe; /* 홀수 행 */
+}
+
+.customTable tbody tr:nth-child(even) {
+  background-color: #fcfcfc; /* 짝수 행 */
+}
+
+.customTable a {
+  color: #0056b3;
+  text-decoration: none;
+  font-weight: 100;
+}
+
+.customTable a:hover {
+  text-decoration: underline;
+}
+
+.customTable td:last-child {
+  color: #0056b3;
+}
+
+/* tfoot 스타일 */
+.customTable tfoot tr {
+  background-color: #f5f5f5; /* 마지막 행 배경색 */
+  font-weight: 200;
+}
+
+.customTable tfoot td {
+  padding: 15px 20px;
+  text-align: center;
+}

--- a/src/components/layout/content/contractManager/statisticsResults/BottomTable.js
+++ b/src/components/layout/content/contractManager/statisticsResults/BottomTable.js
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./BottomTable.css";
+import { fetchIndicators } from "../../../../../api/CommonService";
+
+const BottomTable = ({ agreementId, date }) => {
+  const [indicatorList, setIndicatorList] = useState([]);
+  const [indicatorEtcInfo, setIndicatorEtcInfo] = useState({
+    grade: "-",
+    requestCount: 0,
+    incidentTime: 0,
+  });
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (agreementId && date) {
+        try {
+          const response = await fetchIndicators(agreementId, date);
+          if (response && response.success) {
+            setIndicatorEtcInfo(response.data.indicatorEtcInfo || {});
+            setIndicatorList(response.data.indicatorList || []);
+          } else {
+            setIndicatorEtcInfo({
+              grade: "-",
+              requestCount: 0,
+              incidentTime: 0,
+            });
+            setIndicatorList([]);
+          }
+        } catch (error) {
+          console.error("Failed to fetch indicator data:", error);
+          setIndicatorEtcInfo({ grade: "-", requestCount: 0, incidentTime: 0 });
+          setIndicatorList([]);
+        }
+      }
+    };
+    fetchData();
+  }, [agreementId, date]);
+
+  const handleDetailClick = (evaluationItemId, date) => {
+    if (evaluationItemId && date) {
+      navigate(`/user/indexManagement/detail/${evaluationItemId}/${date}`);
+    } else {
+      console.error("Missing parameters:", { evaluationItemId, date });
+    }
+  };
+
+  return (
+    <table className="customTable">
+      <thead>
+        <tr>
+          <th>지표 구분</th>
+          <th>자동 계산 여부</th>
+          <th>지표 측정일</th>
+          <th>측정 범위</th>
+          <th>평가 점수</th>
+          <th>평가 등급</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {indicatorList.length > 0 ? (
+          indicatorList.map((item, index) => (
+            <tr
+              key={item.evaluationItemId}
+              className={index % 2 === 0 ? "highlightedRow" : ""}
+            >
+              <td>{item.category}</td>
+              <td>{item.auto ? "자동계산" : "수동계산"}</td>
+              <td>{item.date}</td>
+              <td>{item.calculateTime}</td>
+              <td>{item.score}%</td>
+              <td>{item.grade}등급</td>
+              <td>
+                <a
+                  href="#"
+                  onClick={() =>
+                    handleDetailClick(item.evaluationItemId, item.date)
+                  }
+                >
+                  자세히 보기 &gt;
+                </a>
+              </td>
+            </tr>
+          ))
+        ) : (
+          <tr>
+            <td colSpan="6" style={{ textAlign: "center", padding: "1rem" }}>
+              해당 월 지표에 대한 통계값이 없습니다.
+            </td>
+          </tr>
+        )}
+      </tbody>
+      {indicatorList.length > 0 && (
+        <tfoot className="bFoot">
+          <tr>
+            <td>전체</td>
+            <td></td>
+            <td colSpan="3"></td>
+            <td>{indicatorEtcInfo.grade}등급</td>
+            <td></td>
+          </tr>
+        </tfoot>
+      )}
+    </table>
+  );
+};
+
+export default BottomTable;

--- a/src/components/layout/content/contractManager/statisticsResults/IndexManagementContent.js
+++ b/src/components/layout/content/contractManager/statisticsResults/IndexManagementContent.js
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from "react";
+import "../../../../../styles/Content.css";
+import { FaBars } from "react-icons/fa6";
+import { IoPersonCircle } from "react-icons/io5";
+import MiddleIndex from "./MiddleIndex";
+import ContractHeaderV1 from "../../../../common/header/ContractHeaderV1";
+import BottomTable from "./BottomTable";
+
+const IndexManagementContent = ({ isNavOpen, toggleNav, effectClass }) => {
+  // 상태 정의: ContractHeaderV1에서 받은 값을 저장
+  const [selectedAgreementId, setSelectedAgreementId] = useState(
+    localStorage.getItem("selectedAgreementId") || null
+  );
+  const [selectedDate, setSelectedDate] = useState(
+    localStorage.getItem("selectedDate") || ""
+  );
+
+  // 콜백 함수 정의
+  const handleContractSelection = (agreementId, date) => {
+    setSelectedAgreementId(agreementId);
+    setSelectedDate(date);
+
+    // localStorage에 값 저장
+    localStorage.setItem("selectedAgreementId", agreementId);
+    localStorage.setItem("selectedDate", date);
+  };
+
+  // 페이지가 처음 로드될 때 로컬 스토리지에서 값 불러오기
+  useEffect(() => {
+    const savedAgreementId = localStorage.getItem("selectedAgreementId");
+    const savedDate = localStorage.getItem("selectedDate");
+
+    if (savedAgreementId) setSelectedAgreementId(savedAgreementId);
+    if (savedDate) setSelectedDate(savedDate);
+  }, []);
+
+  return (
+    <div
+      className={`pageContent pageContentOffcanvas${effectClass} ${
+        isNavOpen ? "jsOpened" : ""
+      }`}
+    >
+      <button
+        className={`navOpenBtn ${isNavOpen ? "jsHidden" : ""}`}
+        onClick={toggleNav}
+      >
+        <FaBars />
+      </button>
+
+      {/* 프로필 및 환영 메시지 추가 */}
+      <div className="profileSection">
+        <div className="profileInfo">
+          <IoPersonCircle className="profileImg" />
+          <span className="welcomeText">관리자님 환영합니다</span>
+        </div>
+      </div>
+      <hr className="divider" />
+      <div className="content">
+        <div className="contentBox">
+          {/* 자식 컴포넌트에 콜백 함수 전달 */}
+          <ContractHeaderV1 onContractSelect={handleContractSelection} />
+          {/* 상태를 자식 컴포넌트로 전달 */}
+          <MiddleIndex agreementId={selectedAgreementId} date={selectedDate} />
+          <BottomTable agreementId={selectedAgreementId} date={selectedDate} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IndexManagementContent;

--- a/src/components/layout/content/contractManager/statisticsResults/MiddleIndex.css
+++ b/src/components/layout/content/contractManager/statisticsResults/MiddleIndex.css
@@ -1,0 +1,39 @@
+.middle {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  gap: 4rem;
+  padding: 10px 0px;
+}
+
+.totalIndex {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  padding: 1.5rem;
+  text-align: center;
+  flex: 1;
+  transition:
+    transform 0.3s,
+    box-shadow 0.3s;
+}
+
+.totalIndex .title {
+  font-size: 1.1rem;
+  color: #5a5a5a;
+  margin-bottom: 1.1rem;
+  font-weight: 600;
+}
+
+.totalIndex .value {
+  font-size: 2.3rem;
+  font-weight: 800;
+  color: #0056b3;
+}
+
+.totalIndex .subText {
+  font-size: 1rem;
+  color: #5a5a5a;
+  margin-top: 10px;
+  font-weight: 600;
+}

--- a/src/components/layout/content/contractManager/statisticsResults/MiddleIndex.js
+++ b/src/components/layout/content/contractManager/statisticsResults/MiddleIndex.js
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from "react";
+import "./MiddleIndex.css";
+import "../../../../../styles/Font.css";
+import { fetchIndicators } from "../../../../../api/CommonService";
+
+const MiddleIndex = ({ agreementId, date }) => {
+  const [indicatorData, setIndicatorData] = useState({
+    grade: "",
+    requestCount: 0,
+    incidentTime: 0,
+  });
+
+  const formatDowntimeToHours = (time) => {
+    if (time < 60) {
+      return `${time}m`;
+    } else {
+      const hours = Math.floor(time / 60);
+      const minutes = time % 60;
+      return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+    }
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (agreementId && date) {
+        try {
+          const response = await fetchIndicators(agreementId, date);
+          if (response && response.success) {
+            const { grade, requestCount, incidentTime, score } =
+              response.data.indicatorEtcInfo;
+            setIndicatorData({ grade, requestCount, incidentTime, score });
+          } else {
+            setIndicatorData({
+              grade: "-",
+              requestCount: 0,
+              incidentTime: 0,
+              score: 0,
+            });
+          }
+        } catch (error) {
+          console.error("Failed to fetch indicator data:", error);
+          setIndicatorData({
+            grade: "-",
+            requestCount: 0,
+            incidentTime: 0,
+            score: 0,
+          });
+        }
+      }
+    };
+    fetchData();
+  }, [agreementId, date]);
+
+  return (
+    <div className="middle">
+      <div className="totalIndex">
+        <div className="title">종합평가 등급</div>
+        <div className="value">{indicatorData.grade}등급</div>
+        <div className="subText">{indicatorData.score}점</div>
+      </div>
+      <div className="totalIndex">
+        <div className="title">요청 건수</div>
+        <div className="value">{indicatorData.requestCount}건</div>
+      </div>
+      <div className="totalIndex">
+        <div className="title">장애 발생 시간</div>
+        <div className="value">
+          {formatDowntimeToHours(indicatorData.incidentTime)}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MiddleIndex;

--- a/src/components/layout/sidebar/ContactManagerSidebar.js
+++ b/src/components/layout/sidebar/ContactManagerSidebar.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate, useLocation, Route } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import "../../../styles/Sidebar.css";
 import { FiHome, FiTrendingUp } from "react-icons/fi";
 import { FaFileContract, FaTasks } from "react-icons/fa";
@@ -7,40 +7,33 @@ import logo from "../../../assets/images/logo.png";
 import LogoutButton from "../../common/button/LogoutButton.js";
 
 const ContractManagerSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
-  const [activeIndex, setActiveIndex] = useState(0); // 기본값을 0으로 설정
-  const navigate = useNavigate();
+  const [activeIndex, setActiveIndex] = useState();
   const location = useLocation();
 
   // 컴포넌트 마운트 시 URL 경로에 따라 activeIndex 설정
   useEffect(() => {
     const pathToIndexMap = {
       "/contractManager": 0,
-      "/contractManager/contractList": 1,
-      "/contractManager/requestAllocation": 2,
-      "/contractManager/indicatorCalculator": 3,
+      "/contractManager/contractList": 0,
+      "/contractManager/statisticsResult": 1,
+      "/contractManager/indicatorCalculator": 2,
+      "/contractManager/requestAllocation": 3,
     };
 
     const currentPath = location.pathname;
-    const savedIndex = localStorage.getItem("activeIndex");
-
-    if (savedIndex !== null) {
-      setActiveIndex(parseInt(savedIndex, 10));
-    } else if (pathToIndexMap[currentPath] !== undefined) {
+    if (pathToIndexMap[currentPath] !== undefined) {
       setActiveIndex(pathToIndexMap[currentPath]);
     }
-  }, [location]);
+  }, [location.pathname]);
 
-  const handleMenuClick = (index, path) => {
+  const handleMenuClick = (index) => {
     setActiveIndex(index);
-    localStorage.setItem("activeIndex", index); // 로컬 스토리지에 인덱스를 저장
-    navigate(path);
+    toggleNav(); // 사이드바 열림/닫힘 전환
   };
 
   return (
     <nav
-      className={`nav navOffcanvas${effectClass} ${
-        isNavOpen ? "is-opened" : ""
-      }`}
+      className={`nav navOffcanvas${effectClass} ${isNavOpen ? "is-opened" : ""}`}
     >
       <div className="navClose" onClick={toggleNav}></div>
 
@@ -52,51 +45,45 @@ const ContractManagerSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
       <aside>
         <ul className="navList">
           <li className="navItem">
-            <a
-              href="#"
+            <Link
+              to="/contractManager/contractList"
               className={`navLink ${activeIndex === 0 ? "active" : ""}`}
-              onClick={() => handleMenuClick(0, "/contractManager")}
+              onClick={() => handleMenuClick(0)}
             >
-              <FiHome className="navLinkIcon" />홈
-            </a>
+              <FiHome className="navLinkIcon" />
+              계약 관리
+            </Link>
           </li>
           <li className="navItem">
-            <a
-              href="#"
+            <Link
+              to="/contractManager/statisticsResult"
               className={`navLink ${activeIndex === 1 ? "active" : ""}`}
-              onClick={() =>
-                handleMenuClick(1, "/contractManager/contractList")
-              }
+              onClick={() => handleMenuClick(1)}
             >
               <FaFileContract className="navLinkIcon" />
-              계약 관리
-            </a>
+              통계 결과
+            </Link>
           </li>
-
           <li className="navItem">
-            <a
-              href="#"
+            <Link
+              to="/contractManager/indicatorCalculator"
               className={`navLink ${activeIndex === 2 ? "active" : ""}`}
-              onClick={() =>
-                handleMenuClick(2, "/contractManager/requestAllocation")
-              }
-            >
-              <FaTasks className="navLinkIcon" />
-              요청 할당
-            </a>
-          </li>
-
-          <li className="navItem">
-            <a
-              href="#"
-              className={`navLink ${activeIndex === 3 ? "active" : ""}`}
-              onClick={() =>
-                handleMenuClick(3, "/contractManager/indicatorCalculator")
-              }
+              onClick={() => handleMenuClick(2)}
             >
               <FiTrendingUp className="navLinkIcon" />
               지표 계산
-            </a>
+            </Link>
+          </li>
+
+          <li className="navItem">
+            <Link
+              to="/contractManager/requestAllocation"
+              className={`navLink ${activeIndex === 3 ? "active" : ""}`}
+              onClick={() => handleMenuClick(3)}
+            >
+              <FaTasks className="navLinkIcon" />
+              요청 할당
+            </Link>
           </li>
         </ul>
 
@@ -104,7 +91,6 @@ const ContractManagerSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
           <LogoutButton />
         </div>
 
-        {/* 푸터 추가 */}
         <footer className="sidebarFooter">© 2024 SLASH ERP</footer>
       </aside>
     </nav>

--- a/src/components/layout/sidebar/ContactManagerSidebar.js
+++ b/src/components/layout/sidebar/ContactManagerSidebar.js
@@ -5,19 +5,22 @@ import { FiHome, FiTrendingUp } from "react-icons/fi";
 import { FaFileContract, FaTasks } from "react-icons/fa";
 import logo from "../../../assets/images/logo.png";
 import LogoutButton from "../../common/button/LogoutButton.js";
+import { IoCalendarNumberOutline } from "react-icons/io5";
+import { PiCalendarDuotone } from "react-icons/pi";
+import { RiNumbersLine } from "react-icons/ri";
 
 const ContractManagerSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
   const [activeIndex, setActiveIndex] = useState();
   const location = useLocation();
 
-  // 컴포넌트 마운트 시 URL 경로에 따라 activeIndex 설정
+  // Set activeIndex based on URL path
   useEffect(() => {
     const pathToIndexMap = {
-      "/contractManager": 0,
       "/contractManager/contractList": 0,
       "/contractManager/statisticsResult": 1,
-      "/contractManager/indicatorCalculator": 2,
-      "/contractManager/requestAllocation": 3,
+      "/contractManager/annualIndexManagement": 2,
+      "/contractManager/indicatorCalculator": 3,
+      "/contractManager/requestAllocation": 4,
     };
 
     const currentPath = location.pathname;
@@ -28,7 +31,7 @@ const ContractManagerSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
 
   const handleMenuClick = (index) => {
     setActiveIndex(index);
-    toggleNav(); // 사이드바 열림/닫힘 전환
+    toggleNav(); // Toggle sidebar open/close
   };
 
   return (
@@ -54,21 +57,37 @@ const ContractManagerSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
               계약 관리
             </Link>
           </li>
-          <li className="navItem">
+          <li className="navItem2">
+            <span className="navLinkIcon2">
+              <RiNumbersLine />
+            </span>
+            통계 결과
+          </li>
+          <li className="navItemSmall">
             <Link
               to="/contractManager/statisticsResult"
               className={`navLink ${activeIndex === 1 ? "active" : ""}`}
               onClick={() => handleMenuClick(1)}
             >
-              <FaFileContract className="navLinkIcon" />
-              통계 결과
+              <IoCalendarNumberOutline className="navLinkIcon" />
+              월간 통계
+            </Link>
+          </li>
+          <li className="navItemSmall">
+            <Link
+              to="/contractManager/annualIndexManagement"
+              className={`navLink ${activeIndex === 2 ? "active" : ""}`}
+              onClick={() => handleMenuClick(2)}
+            >
+              <PiCalendarDuotone className="navLinkIcon" />
+              연간 통계
             </Link>
           </li>
           <li className="navItem">
             <Link
               to="/contractManager/indicatorCalculator"
-              className={`navLink ${activeIndex === 2 ? "active" : ""}`}
-              onClick={() => handleMenuClick(2)}
+              className={`navLink ${activeIndex === 3 ? "active" : ""}`}
+              onClick={() => handleMenuClick(3)}
             >
               <FiTrendingUp className="navLinkIcon" />
               지표 계산
@@ -78,8 +97,8 @@ const ContractManagerSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
           <li className="navItem">
             <Link
               to="/contractManager/requestAllocation"
-              className={`navLink ${activeIndex === 3 ? "active" : ""}`}
-              onClick={() => handleMenuClick(3)}
+              className={`navLink ${activeIndex === 4 ? "active" : ""}`}
+              onClick={() => handleMenuClick(4)}
             >
               <FaTasks className="navLinkIcon" />
               요청 할당

--- a/src/components/layout/sidebar/RequestManagerSidebar.js
+++ b/src/components/layout/sidebar/RequestManagerSidebar.js
@@ -1,36 +1,27 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import "../../../styles/Sidebar.css";
 import { FiHome } from "react-icons/fi";
 import { FaFileContract } from "react-icons/fa";
 import logo from "../../../assets/images/logo.png";
-import LogoutButton from "../../common/button/LogoutButton.js"
+import LogoutButton from "../../common/button/LogoutButton.js";
 
 const RequestManagerSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
-  const [activeIndex, setActiveIndex] = useState(0); // 기본값 설정
-  const navigate = useNavigate();
+  const [activeIndex, setActiveIndex] = useState();
   const location = useLocation();
 
   useEffect(() => {
     const pathToIndexMap = {
       "/requestManager": 0,
-      "/requestManager/taskDetails": 1,
+      "/requestManager/status": 1,
     };
 
     const currentPath = location.pathname;
-    const savedIndex = localStorage.getItem("activeIndex");
-
-    if (savedIndex !== null) {
-      setActiveIndex(parseInt(savedIndex, 10));
-    } else if (pathToIndexMap[currentPath] !== undefined) {
-      setActiveIndex(pathToIndexMap[currentPath]);
-    }
+    setActiveIndex(pathToIndexMap[currentPath] ?? 0); // 해당 경로에 따라 activeIndex 설정
   }, [location]);
 
-  const handleMenuClick = (index, path) => {
+  const handleMenuClick = (index) => {
     setActiveIndex(index);
-    localStorage.setItem("activeIndex", index);
-    navigate(path);
   };
 
   return (
@@ -49,23 +40,23 @@ const RequestManagerSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
       <aside>
         <ul className="navList">
           <li className="navItem">
-            <a
-              href="#"
+            <Link
+              to="/requestManager"
               className={`navLink ${activeIndex === 0 ? "active" : ""}`}
-              onClick={() => handleMenuClick(0, "/requestManager")}
+              onClick={() => handleMenuClick(0)}
             >
               <FiHome className="navLinkIcon" />홈
-            </a>
+            </Link>
           </li>
           <li className="navItem">
-            <a
-              href="/requestManager/status"
+            <Link
+              to="/requestManager/status"
               className={`navLink ${activeIndex === 1 ? "active" : ""}`}
-              onClick={() => handleMenuClick(1, "/requestManager/status")}
+              onClick={() => handleMenuClick(1)}
             >
               <FaFileContract className="navLinkIcon" />
               업무 내역
-            </a>
+            </Link>
           </li>
         </ul>
 

--- a/src/components/layout/sidebar/UserSidebar.js
+++ b/src/components/layout/sidebar/UserSidebar.js
@@ -3,11 +3,9 @@ import { Link, useLocation } from "react-router-dom";
 import "../../../styles/Content.css";
 import "../../../styles/Sidebar.css";
 import { FiHome, FiTrendingUp } from "react-icons/fi";
-import { MdCalendarMonth, MdQuestionMark } from "react-icons/md";
+import { MdQuestionMark } from "react-icons/md";
 import logo from "../../../assets/images/logo.png";
-import { FaTasks } from "react-icons/fa";
 import LogoutButton from "../../common/button/LogoutButton.js";
-import { LiaCalendarDaySolid } from "react-icons/lia";
 import { PiCalendarDuotone } from "react-icons/pi";
 import { IoCalendarNumberOutline } from "react-icons/io5";
 
@@ -20,9 +18,8 @@ const UserSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
     const pathToIndexMap = {
       "/user": 0,
       "/user/requestManagement": 1,
-      "/user/indexManagement": 2,
       "/user/indexManagement": 3,
-      "/user/indexManagement": 4,
+      "": 4,
     };
 
     const currentPath = location.pathname;

--- a/src/components/layout/sidebar/UserSidebar.js
+++ b/src/components/layout/sidebar/UserSidebar.js
@@ -1,24 +1,28 @@
 import React, { useState, useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import "../../../styles/Content.css";
 import "../../../styles/Sidebar.css";
 import { FiHome, FiTrendingUp } from "react-icons/fi";
-import { MdQuestionMark } from "react-icons/md";
+import { MdCalendarMonth, MdQuestionMark } from "react-icons/md";
 import logo from "../../../assets/images/logo.png";
 import { FaTasks } from "react-icons/fa";
 import LogoutButton from "../../common/button/LogoutButton.js";
+import { LiaCalendarDaySolid } from "react-icons/lia";
+import { PiCalendarDuotone } from "react-icons/pi";
+import { IoCalendarNumberOutline } from "react-icons/io5";
 
 const UserSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
-  const [activeIndex, setActiveIndex] = useState(0); // 디폴트로 홈을 active로 설정
+  const [activeIndex, setActiveIndex] = useState(0); // 기본으로 홈을 active로 설정
   const location = useLocation();
 
-  // 컴포넌트 마운트 시 URL 경로에 따라 activeIndex 설정
+  // 컴포넌트가 마운트될 때 URL 경로에 따라 activeIndex를 설정
   useEffect(() => {
     const pathToIndexMap = {
       "/user": 0,
       "/user/requestManagement": 1,
       "/user/indexManagement": 2,
-      "/user/requestAllocation": 3,
+      "/user/indexManagement": 3,
+      "/user/indexManagement": 4,
     };
 
     const currentPath = location.pathname;
@@ -53,43 +57,47 @@ const UserSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
       <aside>
         <ul className="navList">
           <li className="navItem">
-            <a
-              href="/user"
+            <Link
+              to="/user"
               className={`navLink ${activeIndex === 0 ? "active" : ""}`}
               onClick={() => handleMenuClick(0)}
             >
               <FiHome className="navLinkIcon" />홈
-            </a>
+            </Link>
           </li>
           <li className="navItem">
-            <a
-              href="/user/requestManagement"
+            <Link
+              to="/user/requestManagement"
               className={`navLink ${activeIndex === 1 ? "active" : ""}`}
               onClick={() => handleMenuClick(1)}
             >
               <MdQuestionMark className="navLinkIcon" />
               요청 관리
-            </a>
+            </Link>
           </li>
-          <li className="navItem">
-            <a
-              href="/user/indexManagement"
+          <li className="navItem2">
+            <FiTrendingUp className="navLinkIcon" />
+            통계 결과
+          </li>
+          <li className="navItemSmall">
+            <Link
+              to="/user/indexManagement"
               className={`navLink ${activeIndex === 2 ? "active" : ""}`}
               onClick={() => handleMenuClick(2)}
             >
-              <FiTrendingUp className="navLinkIcon" />
-              지표 관리
-            </a>
+              <IoCalendarNumberOutline className="navLinkIcon" />
+              월간 통계
+            </Link>
           </li>
-          <li className="navItem">
-            <a
-              href="/user/requestAllocation"
+          <li className="navItemSmall">
+            <Link
+              to="/user/indexManagement"
               className={`navLink ${activeIndex === 3 ? "active" : ""}`}
               onClick={() => handleMenuClick(3)}
             >
-              <FaTasks className="navLinkIcon" />
-              요청 할당
-            </a>
+              <PiCalendarDuotone className="navLinkIcon" />
+              연간 통계
+            </Link>
           </li>
         </ul>
 

--- a/src/components/layout/sidebar/UserSidebar.js
+++ b/src/components/layout/sidebar/UserSidebar.js
@@ -2,36 +2,34 @@ import React, { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import "../../../styles/Content.css";
 import "../../../styles/Sidebar.css";
-import { FiHome, FiTrendingUp } from "react-icons/fi";
+import { FiHome } from "react-icons/fi";
 import { MdQuestionMark } from "react-icons/md";
 import logo from "../../../assets/images/logo.png";
 import LogoutButton from "../../common/button/LogoutButton.js";
 import { PiCalendarDuotone } from "react-icons/pi";
 import { IoCalendarNumberOutline } from "react-icons/io5";
+import { RiNumbersLine } from "react-icons/ri";
 
 const UserSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
-  const [activeIndex, setActiveIndex] = useState(0); // 기본으로 홈을 active로 설정
   const location = useLocation();
 
-  // 컴포넌트가 마운트될 때 URL 경로에 따라 activeIndex를 설정
+  // URL 경로에 따라 activeIndex 설정
+  const pathToIndexMap = {
+    "/user": 0,
+    "/user/requestManagement": 1,
+    "/user/indexManagement": 2,
+    "/user/annualIndexManagement": 3, // 연간 통계 경로 맞춰 설정
+  };
+
+  const currentPath = location.pathname;
+  const initialIndex = pathToIndexMap[currentPath] || 0;
+
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
+
   useEffect(() => {
-    const pathToIndexMap = {
-      "/user": 0,
-      "/user/requestManagement": 1,
-      "/user/indexManagement": 3,
-      "": 4,
-    };
-
-    const currentPath = location.pathname;
-    const savedIndex = localStorage.getItem("activeIndex");
-
-    // 저장된 인덱스가 있으면 사용, 없으면 URL을 기반으로 인덱스 설정
-    if (savedIndex !== null) {
-      setActiveIndex(parseInt(savedIndex, 10));
-    } else if (pathToIndexMap[currentPath] !== undefined) {
-      setActiveIndex(pathToIndexMap[currentPath]);
-    }
-  }, [location]);
+    // URL이 변경될 때마다 activeIndex를 업데이트
+    setActiveIndex(initialIndex);
+  }, [location.pathname, initialIndex]);
 
   const handleMenuClick = (index) => {
     setActiveIndex(index);
@@ -73,7 +71,9 @@ const UserSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
             </Link>
           </li>
           <li className="navItem2">
-            <FiTrendingUp className="navLinkIcon" />
+            <span className="navLinkIcon2">
+              <RiNumbersLine />
+            </span>
             통계 결과
           </li>
           <li className="navItemSmall">
@@ -88,7 +88,7 @@ const UserSidebar = ({ isNavOpen, toggleNav, effectClass }) => {
           </li>
           <li className="navItemSmall">
             <Link
-              to="/user/indexManagement"
+              to="/user/annualIndexManagement" // 연간 통계 경로 맞춤
               className={`navLink ${activeIndex === 3 ? "active" : ""}`}
               onClick={() => handleMenuClick(3)}
             >

--- a/src/pages/contractManager/StatisticsResults.js
+++ b/src/pages/contractManager/StatisticsResults.js
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import "../../styles/Content.css";
+import ContractManagerSidebar from "../../components/layout/sidebar/ContactManagerSidebar";
+import IndexManagementContent from "../../components/layout/content/contractManager/statisticsResults/IndexManagementContent";
+const StatisticsResults = () => {
+  const [isNavOpen, setNavOpen] = useState(true);
+  const [effectClass, setEffectClass] = useState(1);
+
+  const toggleNav = () => {
+    setNavOpen(!isNavOpen);
+  };
+  return (
+    <div>
+      <ContractManagerSidebar
+        isNavOpen={isNavOpen}
+        toggleNav={toggleNav}
+        effectClass={effectClass}
+        setEffectClass={setEffectClass}
+      />
+
+      <IndexManagementContent
+        isNavOpen={isNavOpen}
+        toggleNav={toggleNav}
+        effectClass={effectClass}
+      />
+    </div>
+  );
+};
+
+export default StatisticsResults;

--- a/src/shared/Router.js
+++ b/src/shared/Router.js
@@ -14,25 +14,20 @@ import CreateEvaluationItem from "../pages/contractManager/CreateEvaluationItem"
 import EvaluationItemDetail from "../pages/contractManager/EvaluationItemDetail";
 import IndicatorCalculator from "../pages/contractManager/IndicatorCalculator";
 import DetailIndex from "../pages/user/DetailIndex";
-import DetailIndexContent from "../components/layout/content/contractManager/indexManagment/DetailIndexContent";
 import UpdateEvaluationItem from "../pages/contractManager/UpdateEvaluationItem";
 import ProtectedRoute from "../components/common/ProtectedRoute";
 import RequestAllocation from "../pages/contractManager/RequestAllocation";
 import RequestManagerStatus from "../pages/requestManager/RequestManagerStatus";
 import EstimateIndicatorEdit from "../pages/contractManager/EstimateIndicatorEdit";
+import StatisticsResults from "../pages/contractManager/StatisticsResults";
 
-//BrowserRouter를 Router로 감싸는 이유는,
-//SPA의 장점인 브라우저가 깜빡이지 않고 다른 페이지로 이동할 수 있게 만들어줍니다!
 const Router = () => {
   return (
     <BrowserRouter>
       <Routes>
-        {/*
-                        Routes안에 이렇게 작성합니다. 
-                        path는 우리가 흔히 말하는 사용하고싶은 "주소"를 넣어주면 됩니다.
-                        element는 해당 주소로 이동했을 때 보여주고자 하는 컴포넌트를 넣어줍니다.
-        */}
         <Route path="/" element={<Login />} />
+
+        {/* 사용자 권한 페이지들 */}
         <Route path="/user/indexManagement" element={<IndexManagement />} />
         <Route
           path="/user/indexManagement/detail/:evaluationItemId/:date"
@@ -53,6 +48,7 @@ const Router = () => {
               <RequestManagement />
             </ProtectedRoute>
           }
+          // 요청 관리자 권한 페이지들
         />
         <Route
           path="/requestManager"
@@ -62,6 +58,11 @@ const Router = () => {
             </ProtectedRoute>
           }
         />
+        <Route
+          path="/requestManager/status"
+          element={<RequestManagerStatus />}
+        />
+        {/* 계약 관리자 관련 페이지 */}
         <Route
           path="/contractManager"
           element={
@@ -132,12 +133,16 @@ const Router = () => {
         />
 
         <Route
-          path="/contractManager/indexManagement"
-          element={<IndexManagement />}
+          path="/contractManager/statisticsResult"
+          element={<StatisticsResults />}
         />
         <Route
           path="/contractManager/indicatorCalculator"
-          element={<IndicatorCalculator />}
+          element={
+            <ProtectedRoute allowedRoles={["ROLE_CONTRACT_MANAGER"]}>
+              <IndicatorCalculator />
+            </ProtectedRoute>
+          }
         />
         <Route
           path="/contractManager/requestAllocation"
@@ -146,10 +151,6 @@ const Router = () => {
         <Route
           path="/contractManager/autoCal"
           element={<EstimateIndicatorEdit />}
-        />
-        <Route
-          path="/requestManager/status"
-          element={<RequestManagerStatus />}
         />
       </Routes>
     </BrowserRouter>

--- a/src/shared/Router.js
+++ b/src/shared/Router.js
@@ -133,7 +133,7 @@ const Router = () => {
 
         <Route
           path="/contractManager/indexManagement"
-          element={<DetailIndexContent />}
+          element={<IndexManagement />}
         />
         <Route
           path="/contractManager/indicatorCalculator"

--- a/src/styles/Sidebar.css
+++ b/src/styles/Sidebar.css
@@ -3,10 +3,6 @@
 body {
   font-family: "IBM Plex Sans KR", sans-serif;
   background-color: #f0f4f8;
-}
-
-/* 전체 바디 스타일 설정 */
-body {
   width: 100%;
   height: 100vh;
   margin: 0;
@@ -17,98 +13,91 @@ body {
   position: fixed;
   top: 0;
   bottom: 0;
-  width: 15rem; /* 기본 사이드바 너비 */
-  padding: 2rem; /* 콘텐츠 주변 여백 */
+  width: 15rem;
+  padding: 2rem;
   box-sizing: border-box;
-  background-color: #121824; /* 사이드바 배경색 */
+  background-color: #121824;
   color: white;
-  opacity: 0; /* 처음에 보이지 않게 설정 */
+  opacity: 0;
   visibility: hidden;
   box-shadow: 2px 0 2px rgba(0, 0, 0, 0.5);
   border-radius: 0.1rem;
+  transition:
+    opacity 0.3s ease,
+    visibility 0.3s ease;
 }
 
 /* 작은 화면에 맞춘 사이드바 스타일 */
 @media (max-width: 768px) {
   .nav {
-    width: 12rem; /* 화면이 작아졌을 때 사이드바 너비 축소 */
+    width: 12rem;
   }
 }
 
-/* 더 작은 화면에 맞춘 스타일 */
 @media (max-width: 576px) {
   .nav {
-    width: 10rem; /* 화면이 더 작아졌을 때 사이드바 너비 축소 */
-    padding: 10px; /* 작은 화면에서 여백 축소 */
+    width: 10rem;
+    padding: 10px;
   }
 }
 
 /* 사이드바 닫기 버튼 스타일 */
 .navClose {
   position: absolute;
-  top: 7px; /* 70%로 조정 */
-  right: 0.7px; /* 70%로 조정 */
-  width: 28px; /* 40px의 70%로 조정 */
+  top: 7px;
+  right: 7px;
+  width: 28px;
+  height: 28px;
   cursor: pointer;
 }
 
-/* 닫기 버튼의 선 스타일 */
 .navClose:before,
 .navClose:after {
   content: "";
   display: block;
-  width: 2.8px; /* 4px의 70%로 조정 */
-  height: 19.6px; /* 28px의 70%로 조정 */
+  width: 4px;
+  height: 28px;
   background-color: #f0f4f8;
   border-radius: 10px;
   position: absolute;
-  transition: all 0.2s linear;
+  top: 0;
+  left: 12px;
+  transform-origin: center;
 }
 
-/* 닫기 버튼의 왼쪽 대각선 선 */
 .navClose:before {
   transform: rotate(-45deg);
-  top: 0;
-  left: 12.6px; /* 18px의 70%로 조정 */
 }
 
-/* 닫기 버튼의 오른쪽 대각선 선 */
 .navClose:after {
   transform: rotate(45deg);
-  top: 0;
-  right: 12.6px; /* 18px의 70%로 조정 */
 }
 
 .navHeader {
   display: flex;
   align-items: center;
-  justify-content: center; /* 왼쪽 정렬 */
-  margin-bottom: 3rem; /* 아래 여백 */
-  margin-top: 2.5rem;
-  margin-left: -1rem;
+  justify-content: center;
+  margin: 3rem 0 1rem;
 }
 
 /* 사이드바 제목 스타일 */
 .sidebarTitle {
-  font-size: 1.5rem; /* 제목 크기 */
+  font-size: 1.5rem;
   font-weight: bold;
-  text-transform: uppercase; /* 대문자 변환 */
+  text-transform: uppercase;
   color: white;
   transition: color 0.3s;
 }
 
 .logo {
-  width: 7rem; /* 로고의 폭을 설정 */
-  height: auto; /* 비율에 맞춰 높이 자동 조정 */
-  display: inline-block; /* 인라인 블록으로 설정하여 텍스트와 수평 정렬 */
-  vertical-align: middle; /* 중간 정렬 */
-  margin-right: -1rem; /* 텍스트와의 간격 조정 */
-  margin-left: -2.3rem;
+  width: 7rem;
+  height: auto;
+  margin-left: -1rem;
 }
 
 @media (max-width: 576px) {
   .logo {
-    width: 4rem; /* 작은 화면에서 로고 크기 축소 */
+    width: 4rem;
   }
 }
 
@@ -116,10 +105,8 @@ body {
   padding: 0.4rem;
 }
 
-/* 사이드바가 열렸을 때 */
+/* 사이드바 열림 상태 */
 .navOffcanvas1.is-opened {
-  z-index: 100;
-  left: 0;
   opacity: 1;
   visibility: visible;
 }
@@ -128,7 +115,7 @@ body {
 .navList {
   list-style-type: none;
   padding: 0;
-  margin: 1rem 0 0;
+  margin: 1rem 0;
 }
 
 /* 메뉴 링크 스타일 */
@@ -137,65 +124,35 @@ body {
   align-items: center;
   color: #fff;
   text-decoration: none;
-  position: relative;
   padding: 10px 20px;
   width: 11rem;
-  transition: none; /* 애니메이션 제거 */
-  border-top-left-radius: 20px;
-  border-bottom-left-radius: 20px;
+  transition: background-color 0.3s;
+  border-radius: 20px 0 0 20px;
 }
 
-/* 동일한 스타일을 hover, active, focus 모두에 적용 */
 .navLink:hover,
 .navLink.active,
 .navLink:focus {
   color: #121824;
   background-color: #f0f4f8;
-  outline: none;
-  position: relative;
-  border-top-left-radius: 200px;
-  border-bottom-left-radius: 200px;
-  box-shadow: inset 5px 0 5px -3px rgba(0, 0, 0, 0.4); /* 추가: hover 효과 유지 */
+  box-shadow: inset 5px 0 5px -3px rgba(0, 0, 0, 0.4);
 }
 
-.navLink:hover::after,
-.navLink.active::after,
-.navLink:focus::after {
-  content: "";
-  position: absolute;
-  background-color: transparent;
-  bottom: 100%;
-  right: 0;
-  height: 35px;
-  width: 37px;
-  border-bottom-right-radius: 100%;
-  box-shadow: 0 20px 0 0 #f0f4f8;
-}
-
-.navLink:hover::before,
-.navLink.active::before,
-.navLink:focus::before {
-  content: "";
-  position: absolute;
-  background-color: transparent;
-  top: 49px;
-  right: 0;
-  height: 35px;
-  width: 37px;
-  border-top-right-radius: 100%;
-  box-shadow: 0 -20px 0 0 #f0f4f8;
+.navItem2 {
+  margin-left: 16px;
+  margin-bottom: 7px;
+  margin-top: 7px;
 }
 
 .navItemSmall {
-  margin-left: 30px;
+  margin-left: 20px;
   font-size: 0.8rem;
   color: #e2e0e0;
   padding: 6px 20px;
   width: 11rem;
   display: flex;
   align-items: center;
-  border-top-left-radius: 20px;
-  border-bottom-left-radius: 20px;
+  border-radius: 20px 0 0 20px;
 }
 
 /* 로그아웃 버튼 스타일 */

--- a/src/styles/Sidebar.css
+++ b/src/styles/Sidebar.css
@@ -87,12 +87,13 @@ body {
   text-transform: uppercase;
   color: white;
   transition: color 0.3s;
+  margin-left: -10px;
 }
 
 .logo {
   width: 7rem;
   height: auto;
-  margin-left: -1rem;
+  margin-left: -3rem;
 }
 
 @media (max-width: 576px) {
@@ -124,7 +125,7 @@ body {
   align-items: center;
   color: #fff;
   text-decoration: none;
-  padding: 10px 20px;
+  padding: 11px 16px;
   width: 11rem;
   transition: background-color 0.3s;
   border-radius: 20px 0 0 20px;
@@ -139,16 +140,19 @@ body {
 }
 
 .navItem2 {
-  margin-left: 16px;
+  margin-left: 17px;
   margin-bottom: 7px;
-  margin-top: 7px;
+  margin-top: 10px;
+}
+.navLinkIcon2 {
+  padding: 0.4rem;
 }
 
 .navItemSmall {
   margin-left: 20px;
   font-size: 0.8rem;
   color: #e2e0e0;
-  padding: 6px 20px;
+  padding: 1px 20px;
   width: 11rem;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 🍀이슈 번호
- closes #141 

## ✅ 구현 내용
- [x] 사이드바 권한 별 탭 이름과 링크 정리 
- [x] 사이드바 클릭 css 수정
- [x] 계약 관리자 권한에서의 통계 결과 페이지 생성
- [x] 사이드바에서 탭 클릭 후 의도치 않게 첫 번째 탭으로 돌아가는 문제 해결
- [x] <Link>탭 사용해서 페이지 전체를 다시 로드하지 않고도 URL을 업데이트 및 앱에 저장된 상태 보존 

## 🐳고민사항 & 기타 & 구현한 화면
- 수지 언니, 계약 관리 화면에서 `<Link>` 탭으로 페이지 이동 방식을 바꿨어요. 페이지 이동 시 상태가 보존되는지, 그리고 이전 페이지로 돌아갈 때도 상태가 유지되는지 확인 부탁드려요. 😊
- 계약 관리자 탭 화면
![image](https://github.com/user-attachments/assets/cec8b6b1-f192-4c0a-bed4-50e6f1ef385c)
- 요청 관리자 탭 화면
![image](https://github.com/user-attachments/assets/a2c585ac-1eda-43b4-85fd-edab1dee3755)
- 사용자 관리자 탭 화면
![image](https://github.com/user-attachments/assets/c1ba5a83-1ccb-496d-9fc4-408d4cbc67eb)

